### PR TITLE
Add solidity compilers for uniswap sdk and openzepplin. Bump uniswap …

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,22 @@ if (!process.env.GOERLI_PRIVATE_KEY) {
 }
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.17",
+  solidity: {
+    compilers: [
+      {
+        version: "0.7.0"
+      },
+      {
+        version: "0.7.5"
+      },
+      {
+        version: "0.8.0"
+      },
+      {
+        version: "0.8.17"
+      }
+    ]
+  },
   paths: {
     sources: './src/contracts'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.0",
-        "@uniswap/v2-core": "^1.0.1",
-        "@uniswap/v2-periphery": "^1.1.0-beta.0",
+        "@openzeppelin/contracts": "^4.8.0",
+        "@uniswap/v3-periphery": "^1.4.3",
         "dotenv": "^16.0.3",
         "hardhat": "^2.12.2",
         "ts-node": "^10.9.1",
@@ -1570,6 +1570,12 @@
         "hardhat": "^2.0.4"
       }
     },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "dev": true
+    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -1949,9 +1955,9 @@
       }
     },
     "node_modules/@uniswap/lib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-1.1.1.tgz",
-      "integrity": "sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==",
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1966,27 +1972,36 @@
         "node": ">=10"
       }
     },
-    "node_modules/@uniswap/v2-periphery": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz",
-      "integrity": "sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==",
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.0.tgz",
+      "integrity": "sha512-kSC4djMGKMHj7sLMYVnn61k9nu+lHjMIxgg9CDQT+s2QYLoA56GbSK9Oxr+qJXzzygbkrmuY6cwgP6cW2JXPFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.3.tgz",
+      "integrity": "sha512-80c+wtVzl5JJT8UQskxVYYG3oZb4pkhY0zDe0ab/RX4+8f9+W5d8wI4BT0wLB0wFQTSnbW+QdBSpkHA/vRyGBA==",
       "dev": true,
       "dependencies": {
-        "@uniswap/lib": "1.1.1",
-        "@uniswap/v2-core": "1.0.0"
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "1.0.1",
+        "@uniswap/v3-core": "1.0.0",
+        "base64-sol": "1.0.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/@uniswap/v2-periphery/node_modules/@uniswap/v2-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.0.tgz",
-      "integrity": "sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@uniswap/v3-periphery/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.0.9",
@@ -2385,6 +2400,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==",
+      "dev": true
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -10196,6 +10217,12 @@
         "undici": "^5.4.0"
       }
     },
+    "@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "dev": true
+    },
     "@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -10514,9 +10541,9 @@
       }
     },
     "@uniswap/lib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-1.1.1.tgz",
-      "integrity": "sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==",
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
       "dev": true
     },
     "@uniswap/v2-core": {
@@ -10525,20 +10552,29 @@
       "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
       "dev": true
     },
-    "@uniswap/v2-periphery": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz",
-      "integrity": "sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==",
+    "@uniswap/v3-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.0.tgz",
+      "integrity": "sha512-kSC4djMGKMHj7sLMYVnn61k9nu+lHjMIxgg9CDQT+s2QYLoA56GbSK9Oxr+qJXzzygbkrmuY6cwgP6cW2JXPFA==",
+      "dev": true
+    },
+    "@uniswap/v3-periphery": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.3.tgz",
+      "integrity": "sha512-80c+wtVzl5JJT8UQskxVYYG3oZb4pkhY0zDe0ab/RX4+8f9+W5d8wI4BT0wLB0wFQTSnbW+QdBSpkHA/vRyGBA==",
       "dev": true,
       "requires": {
-        "@uniswap/lib": "1.1.1",
-        "@uniswap/v2-core": "1.0.0"
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "1.0.1",
+        "@uniswap/v3-core": "1.0.0",
+        "base64-sol": "1.0.1"
       },
       "dependencies": {
-        "@uniswap/v2-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.0.tgz",
-          "integrity": "sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==",
+        "@openzeppelin/contracts": {
+          "version": "3.4.2-solc-0.7",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+          "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
           "dev": true
         }
       }
@@ -10843,6 +10879,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==",
       "dev": true
     },
     "bcrypt-pbkdf": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",
-    "@uniswap/v2-core": "^1.0.1",
-    "@uniswap/v2-periphery": "^1.1.0-beta.0",
+    "@openzeppelin/contracts": "^4.8.0",
+    "@uniswap/v3-periphery": "^1.4.3",
     "dotenv": "^16.0.3",
     "hardhat": "^2.12.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "scripts": {
+    "compile": "npx hardhat compile",
+    "goerli": "npx hardhat run scripts/deploy.ts --network goerli"
   }
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,19 +1,10 @@
 import { ethers } from "hardhat";
 
 async function main() {
-
-  console.log(1); // dm
-
   const flyweightFactory = await ethers.getContractFactory("Flyweight");
-
-  console.log(2); // dm
-
   const flyweightContract = await flyweightFactory.deploy();
-
-  console.log(3); // dm
-
+  console.log('Deploying...');
   await flyweightContract.deployed();
-
   console.log(`Deployed to ${flyweightContract.address}`);
 }
 

--- a/src/contracts/Flyweight.sol
+++ b/src/contracts/Flyweight.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
-import '@uniswap/v2-periphery/contracts/UniswapV2Router02.sol';
-import '@uniswap/v2-periphery/contracts/interfaces/IERC20.sol';
+import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract Flyweight {
     struct Order {
@@ -15,33 +15,50 @@ contract Flyweight {
         OrderTriggerDirection direction;
         uint tokenInAmount;
     }
-    struct Price {
-        string token0;
-        string token1;
+    struct NewPriceItem {
+        string symbol;
         string price;
-        string unixTimestamp;
     }
 
-    enum OrderState { UNTRIGGERED, TRIGGERED, EXECUTED }
+    event PriceUpdated (
+        uint timestamp,
+        string symbol,
+        string oldPrice,
+        string newPrice
+    );
+
+    event OrderTriggered (
+        uint orderId
+    );
+
+    event OrderExecuted (
+        uint orderId
+    );
+
+    enum OrderState { UNTRIGGERED, EXECUTED }
     enum OrderTriggerDirection { BELOW, EQUAL, ABOVE }
 
     uint public ordersCount;
-    uint public pricesCount;
     mapping(uint => Order) public orders;
-    mapping(uint => Price) public prices;
-
+    mapping(string => string) public prices;
     mapping(string => address) public tokenAddresses;
 
-    // TODO: solidity constructor to approve UNISWAP spending via IERC20
     constructor() {
-        tokenAddresses["UNI"] = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984";
-        tokenAddresses["WETH"] = "0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6";
+        tokenAddresses["UNI"] = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984;
+        tokenAddresses["WETH"] = 0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6;
+
+        address uniswapRouterAddress = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+        IERC20 uni = IERC20(tokenAddresses["UNI"]);
+        IERC20 weth = IERC20(tokenAddresses["WETH"]);
+        uni.approve(uniswapRouterAddress, type(uint).max);
+        weth.approve(uniswapRouterAddress, type(uint).max);
     }
 
     function addNewOrder(string calldata tokenIn, string calldata tokenOut, string calldata tokenInTriggerPrice, OrderTriggerDirection direction, uint tokenInAmount) external returns(uint) {
         uint id = ordersCount;
         orders[id] = Order({
             id: id,
+            owner: msg.sender,
             orderState: OrderState.UNTRIGGERED,
             tokenIn: tokenIn,
             tokenOut: tokenOut,
@@ -54,27 +71,55 @@ contract Flyweight {
         return id;
     }
 
-    function storePricesAndProcessTriggeredOrderIds(Price[] calldata newPrices, uint[] calldata newTriggeredOrderIds) external {
-        for (uint i = 0; i < newPrices.length; i++) {
-            prices[pricesCount] = newPrices[i];
-            pricesCount++;
+    function storePricesAndProcessTriggeredOrderIds(NewPriceItem[] calldata newPriceItems, uint[] calldata newTriggeredOrderIds) external {
+        for (uint i = 0; i < newPriceItems.length; i++) {
+            NewPriceItem memory item = newPriceItems[i];
+            string memory oldPrice = prices[item.symbol];
+            prices[item.symbol] = item.price;
+
+            emit PriceUpdated({
+                timestamp: block.timestamp,
+                symbol: item.symbol,
+                oldPrice: oldPrice,
+                newPrice: item.price
+            });
         }
 
         for (uint i = 0; i < newTriggeredOrderIds.length; i++) {
             uint orderId = newTriggeredOrderIds[i];
-            orders[orderId].orderState = OrderState.TRIGGERED;
+            emit OrderTriggered({
+                orderId: orderId
+            });
+            
+            executeOrderId(orderId);
+            emit OrderExecuted({
+                orderId: orderId
+            });
         }
     }
 
-    function processTriggeredOrderIds(uint[] calldata newTriggeredOrderIds) private {
-        for (uint i = 0; i < newTriggeredOrderIds.length; i++) {
-            uint orderId = newTriggeredOrderIds[i];
-            Order order = orders[orderId];
-            address[] path = [tokenAddresses[order.tokenIn], tokenAddresses[order.tokenOut]];
-            uint tokenOutMinQuote = 0;  // todo: when front-end is made, it should allow user-defined max slippage
-            UniswapV2Router02.swapExactTokensForTokens(order.tokenInAmount, tokenOutMinQuote, path, order.owner, block.timestamp);
+    function executeOrderId(uint orderId) private {
+        Order storage order = orders[orderId];
+        uint balance = IERC20(address(tokenAddresses[order.tokenIn])).balanceOf(address(this));
+        require(balance >= order.tokenInAmount);
 
-            order.orderState = OrderState.EXECUTED;
-        }
+        address[2] memory path = [tokenAddresses[order.tokenIn], tokenAddresses[order.tokenOut]];
+        uint tokenOutMinQuote = 0;  // todo: when front-end is made, it should allow user-defined max slippage
+
+        address uniswapRouterAddress = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+        ISwapRouter swapRouter = ISwapRouter(uniswapRouterAddress);
+        ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+            tokenIn: path[0],
+            tokenOut: path[1],
+            fee: 3000,
+            recipient: order.owner,
+            deadline: block.timestamp,
+            amountIn: order.tokenInAmount,
+            amountOutMinimum: tokenOutMinQuote,
+            sqrtPriceLimitX96: 0
+        });
+
+        swapRouter.exactInputSingle(swapParams);
+        order.orderState = OrderState.EXECUTED;
     }
 }


### PR DESCRIPTION
- Add solidity compilers for uniswap sdk and openzepplin.
- Bump uniswap sdk from v2 to v3.
- Add npm scripts for compiling and deploying with hardhat.
- Add event logs for price & order state updates.
- Add token approvals for UNI & WETH to the uniswap router.
- Add code to execute swap for triggered orders.