### PR TITLE
Only allow addresses to have 1 order pending deposit

### DIFF
--- a/src/contracts/Flyweight.sol
+++ b/src/contracts/Flyweight.sol
@@ -107,9 +107,14 @@ contract Flyweight {
         OrderTriggerDirection direction,
         uint tokenInAmount
     ) external onlyEoa returns (uint) {
+        // Only allow 1 pending order per user
         uint[] storage orderIds = orderIdsByAddress[msg.sender];
-        uint lastOrderId = orderIds[orderIds.length - 1];
-        require(orders[lastOrderId].orderState != OrderState.PENDING_DEPOSIT); // Only allow 1 pending order per user
+        if (orderIds.length > 0) {
+            uint lastOrderId = orderIds[orderIds.length - 1];
+            require(
+                orders[lastOrderId].orderState != OrderState.PENDING_DEPOSIT
+            );
+        }
 
         uint id = ordersCount;
         orders[id] = Order({


### PR DESCRIPTION
- Add modifier to only allow calls from externally owned accounts. Change cancel method to support the new "PENDING_DEPOSIT" order state. Change addOrder method to restrict users to 1 simultaneous pending order at a time